### PR TITLE
signMessage, Payment with data

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -93,6 +93,14 @@ export default class Client {
             );
             customMessages.push(assetPayment);
           }
+          if (payload.data) {
+            customMessages.push({
+              app: 'data',
+              payload_hash: getBase64Hash(payload.data, bJsonBased),
+              payload_location: 'inline',
+              payload: payload.data,
+            });
+          }
         } else {
           customMessages.push({
             app,
@@ -113,6 +121,7 @@ export default class Client {
           witness_list_unit: lightProps.witness_list_unit,
           timestamp: Math.round(Date.now() / 1000),
         };
+
 
         const author = { address, authentifiers: {} };
         if (isDefinitionRequired) {


### PR DESCRIPTION
- Added `signMessage(message, wif)` in utils. It returns a signed object like this ocore function in non network aware mode: https://github.com/byteball/ocore/blob/2a9d536e34472ba04456720235c199766edaa55c/signed_message.js#L27
As second parameter it takes a WIF or a conf object like for client.post()
- Added the possibility to add data payload to a payment, this is useful for AA triggering.
The data are to be added to payment parameters, example:
```
const params = {
	outputs: [
		{ address: conf.aa_address, amount: 10000 }
	],
	data: {
		withdraw: 1
	}
};

const result = await client.post.payment(params, conf);
```
