### PR TITLE
Compose multi apps

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -68,5 +68,8 @@
       "outputs": "array",
       "asset": "string"
     }
-  }
+	},
+	"multi" : {
+		"params": "object"
+	}
 }

--- a/src/client.js
+++ b/src/client.js
@@ -20,6 +20,7 @@ import {
   getBase64Hash,
   getUnitHashToSign,
   getUnitHash,
+  getLength,
 } from './internal';
 import api from './api.json';
 import apps from './apps.json';
@@ -45,6 +46,15 @@ export default class Client {
 
     this.compose = {
       async message(app, payload, options = {}) {
+        const messages = app === 'multi' ? payload : [{ app, payload }];
+
+        messages.sort(a => {
+          return a.app === 'payment' && !a.payload.asset ? -1 : 1; // we place byte payment message first
+        });
+        if (messages[0].app !== 'payment' || messages[0].payload.asset)
+          // if no byte payment, we add one
+          messages.unshift({ app: 'payment', payload: { outputs: [] } });
+
         let isDefinitionRequired = false;
         const conf =
           typeof options === 'object'
@@ -75,45 +85,38 @@ export default class Client {
             `Definition chash of address doesn't match the definition chash provided`,
           );
 
-        const bytePayment = await createPaymentMessage(
-          self,
-          null,
-          app !== 'payment' || payload.asset ? [] : payload.outputs,
-          address,
-        );
-        const customMessages = [bytePayment];
+        const payloadsLength = messages.reduce(
+          (a, b) => a + 50 + getLength(b.app) + getLength(b.payload),
+          0,
+        ); // 50 is equal to 'inline' + hash length
 
-        if (app === 'payment') {
-          if (payload.asset) {
+        async function createUnitMessage(message) {
+          if (message.app === 'payment') {
             const assetPayment = await createPaymentMessage(
               self,
-              payload.asset,
-              payload.outputs,
+              message.payload.asset,
+              message.payload.outputs,
               address,
+              payloadsLength,
             );
-            customMessages.push(assetPayment);
+            assetPayment.payload.outputs.sort(sortOutputs);
+            assetPayment.payload_hash = getBase64Hash(assetPayment.payload, bJsonBased);
+            return assetPayment;
           }
-          if (payload.data) {
-            customMessages.push({
-              app: 'data',
-              payload_hash: getBase64Hash(payload.data, bJsonBased),
-              payload_location: 'inline',
-              payload: payload.data,
-            });
-          }
-        } else {
-          customMessages.push({
-            app,
-            payload_hash: getBase64Hash(payload, bJsonBased),
+          return {
+            app: message.app,
+            payload_hash: getBase64Hash(message.payload, bJsonBased),
             payload_location: 'inline',
-            payload,
-          });
+            payload: message.payload,
+          };
         }
+
+        const unitMessages = await Promise.all(messages.map(createUnitMessage));
 
         const unit = {
           version: conf.testnet ? VERSION_TESTNET : VERSION,
           alt: conf.testnet ? ALT_TESTNET : ALT,
-          messages: [...customMessages],
+          messages: [...unitMessages],
           authors: [],
           parent_units: lightProps.parent_units,
           last_ball: lightProps.last_stable_mc_ball,
@@ -121,7 +124,6 @@ export default class Client {
           witness_list_unit: lightProps.witness_list_unit,
           timestamp: Math.round(Date.now() / 1000),
         };
-
 
         const author = { address, authentifiers: {} };
         if (isDefinitionRequired) {
@@ -143,14 +145,9 @@ export default class Client {
         const headersCommission = getHeadersSize(unit);
         const payloadCommission = getTotalPayloadSize(unit);
 
-        customMessages[0].payload.outputs[0].amount -= headersCommission + payloadCommission;
-        customMessages[0].payload.outputs.sort(sortOutputs);
-        customMessages[0].payload_hash = getBase64Hash(customMessages[0].payload, bJsonBased);
-
-        if (payload.asset) {
-          customMessages[1].payload.outputs.sort(sortOutputs);
-          customMessages[1].payload_hash = getBase64Hash(customMessages[1].payload, bJsonBased);
-        }
+        unitMessages[0].payload.outputs[0].amount -= headersCommission + payloadCommission;
+        unitMessages[0].payload.outputs.sort(sortOutputs);
+        unitMessages[0].payload_hash = getBase64Hash(unitMessages[0].payload, bJsonBased);
 
         unit.headers_commission = headersCommission;
         unit.payload_commission = payloadCommission;
@@ -159,7 +156,7 @@ export default class Client {
         unit.authors[0].authentifiers = {};
         unit.authors[0].authentifiers[path] = sign(textToSign, privKeyBuf);
 
-        unit.messages = [...customMessages];
+        unit.messages = [...unitMessages];
         unit.unit = getUnitHash(unit);
 
         return unit;

--- a/src/client.js
+++ b/src/client.js
@@ -93,6 +93,14 @@ export default class Client {
             );
             customMessages.push(assetPayment);
           }
+          if (payload.data) {
+            customMessages.push({
+              app: 'data',
+              payload_hash: getBase64Hash(payload.data, bJsonBased),
+              payload_location: 'inline',
+              payload: payload.data,
+            });
+          }
         } else {
           customMessages.push({
             app,
@@ -113,6 +121,7 @@ export default class Client {
           witness_list_unit: lightProps.witness_list_unit,
           timestamp: Math.round(Date.now() / 1000),
         };
+
 
         const author = { address, authentifiers: {} };
         if (isDefinitionRequired) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 export const DEFAULT_NODE = 'wss://obyte.org/bb';
-export const VERSION = '1.0';
+export const VERSION = '2.0';
 export const VERSION_TESTNET = '2.0t';
 export const VERSION_WITHOUT_TIMESTAMP = '1.0';
 export const ALT = '1';

--- a/src/internal.js
+++ b/src/internal.js
@@ -21,10 +21,11 @@ export const camelCase = input =>
 export const repeatString = (str, times) =>
   str.repeat ? str.repeat(times) : new Array(times + 1).join(str);
 
-export async function createPaymentMessage(client, asset, outputs, address) {
+export async function createPaymentMessage(client, asset, outputs, address, payloadLength) {
   const amount = outputs.reduce((a, b) => a + b.amount, 0);
 
-  const targetAmount = asset ? amount : 1000 + amount;
+  const targetAmount = asset ? amount : 700 + payloadLength + amount;
+
   const coinsForAmount = await client.api.pickDivisibleCoinsForAmount({
     addresses: [address],
     last_ball_mci: 1000000000000000,
@@ -42,6 +43,9 @@ export async function createPaymentMessage(client, asset, outputs, address) {
 
   if (asset) {
     payload.asset = asset;
+    if (payload.outputs[0].amount === 0)
+      // amount 0 output is not valid
+      payload.outputs = payload.outputs.slice(1);
   }
 
   return {
@@ -316,7 +320,7 @@ export function chashGetChash160(data) {
 
 export const toPublicKey = privKey => ecdsa.publicKeyCreate(privKey).toString('base64');
 
-function getLength(value) {
+export function getLength(value) {
   if (value === null) return 0;
   switch (typeof value) {
     case 'string':


### PR DESCRIPTION
Changes proposed in this pull request:
- Units having different types of messages can be composed, enabling multiple asset payments. This is done with `client.post.multi(params, wif, function(err, result)`, `params` being an array containing app objects, like:
```
[
  {
    app: 'payment',
    payload:{
	asset
	outputs: [{
	amount
	address
	}]
    },
  {
    app: 'data_feed',
    payload: {
      timestamp: Date.now()
    },
   {
    app:'text',
    payload: 'hello'
   }
]
```
- Calculation of target amount more accurate
- Fix a bug avoiding to spent all assets from an address
- Upgrade network version to `2.0`
