### PR TITLE
Compose multi apps unit

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -68,5 +68,8 @@
       "outputs": "array",
       "asset": "string"
     }
-  }
+	},
+	"multi" : {
+		"params": "object"
+	}
 }

--- a/src/client.js
+++ b/src/client.js
@@ -9,7 +9,6 @@ import {
   VERSION_WITHOUT_TIMESTAMP,
 } from './constants';
 import {
-  repeatString,
   createPaymentMessage,
   sortOutputs,
   mapAPI,
@@ -131,16 +130,6 @@ export default class Client {
           author.definition = definition;
         }
 
-        const assocSigningPaths = {};
-        const assocLengthsBySigningPaths = { r: 88 };
-        const arrSigningPaths = Object.keys(assocLengthsBySigningPaths);
-        assocSigningPaths[address] = arrSigningPaths;
-        for (let j = 0; j < arrSigningPaths.length; j += 1) {
-          author.authentifiers[arrSigningPaths[j]] = repeatString(
-            '-',
-            assocLengthsBySigningPaths[arrSigningPaths[j]],
-          );
-        }
         unit.authors.push(author);
 
         const headersCommission = getHeadersSize(unit);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 export const DEFAULT_NODE = 'wss://obyte.org/bb';
-export const VERSION = '1.0';
+export const VERSION = '2.0';
 export const VERSION_TESTNET = '2.0t';
 export const VERSION_WITHOUT_TIMESTAMP = '1.0';
 export const ALT = '1';

--- a/src/internal.js
+++ b/src/internal.js
@@ -4,6 +4,7 @@ import base32 from 'thirty-two';
 import { VERSION_WITHOUT_TIMESTAMP } from './constants';
 
 const PARENT_UNITS_SIZE = 2 * 44;
+const SIGNATURE_SIZE = 88;
 const PI = '14159265358979323846264338327950288419716939937510';
 const STRING_JOIN_CHAR = '\x00';
 const ZERO_STRING = '00000000';
@@ -17,9 +18,6 @@ export const camelCase = input =>
     .map(p => p.charAt(0).toUpperCase() + p.slice(1))
     .join('')
     .replace(/^\w/, c => c.toLowerCase());
-
-export const repeatString = (str, times) =>
-  str.repeat ? str.repeat(times) : new Array(times + 1).join(str);
 
 export async function createPaymentMessage(
   client,
@@ -366,7 +364,7 @@ export function getHeadersSize(objUnit) {
   if (objUnit.version === VERSION_WITHOUT_TIMESTAMP) delete objHeader.timestamp;
   delete objHeader.messages;
   delete objHeader.parent_units; // replaced with PARENT_UNITS_SIZE
-  return getLength(objHeader) + PARENT_UNITS_SIZE;
+  return getLength(objHeader) + PARENT_UNITS_SIZE + SIGNATURE_SIZE; // unit is always single authored thus only has 1 signature in authentifiers
 }
 
 export function getTotalPayloadSize(objUnit) {

--- a/test/internal.spec.js
+++ b/test/internal.spec.js
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { camelCase, repeatString, sortOutputs, mapAPI, sign, toPublicKey } from '../src/internal';
+import { camelCase, sortOutputs, mapAPI, sign, toPublicKey } from '../src/internal';
 
 describe('internal', () => {
   describe('camelCase', () => {
@@ -12,15 +12,6 @@ describe('internal', () => {
     it('should handle method names with prefix', () => {
       expect(camelCase('light/load')).toEqual('load');
       expect(camelCase('hub/get_interesting_data')).toEqual('getInterestingData');
-    });
-  });
-
-  describe('repeatString', () => {
-    it('should repeat string', () => {
-      expect(repeatString('hey', 1)).toEqual('hey');
-      expect(repeatString('hello', 3)).toEqual('hellohellohello');
-
-      expect(repeatString(5, 2)).toEqual('55');
     });
   });
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Units having different types of messages can be composed, enabling multiple asset payments. This is done with client.post.multi(params, wif, function(err, result), `params` being an array containing app objects, like:
```
[
  {
    app: 'payment',
    payload:{
	asset
	outputs: [{
	amount
	address
	}]
    },
  {
    app: 'data_feed',
    payload: {
      timestamp: Date.now()
    },
   {
    app:'text',
    payload: 'hello'
   }
]
```
- Upgrade network version to 2.0
- Deprecate the ability to add `payload.data` to a payment payload (introduced in last version), client.post.multi should be used instead
- Calculation of target amount more accurate
- Fix a bug avoiding to spent all assets from an address
- Specify real last ball mci when picking inputs to avoid picking foreign unconfirmed ones
- Simplify header commission calculation and remove internal function `repeatString`